### PR TITLE
Refactor/remove 22yc update homepage

### DIFF
--- a/src/Header/Header.jsx
+++ b/src/Header/Header.jsx
@@ -43,7 +43,7 @@ export default function Navbar() {
     { path: '/events', label: 'Events' },
     { path: '/team', label: 'Team' },
     { path: '/interview-experience', label: 'Interview Experience' },
-    { path: '/22yc-register', label: '22 Yards Of Code', special: true }
+    // { path: '/22yc-register', label: '22 Yards Of Code', special: true }
   ];
 
   return (

--- a/src/app/events/events.jsx
+++ b/src/app/events/events.jsx
@@ -198,7 +198,7 @@ const eventData = [
         "ActualDate": "2025-05-23",
         "Priority": 2,
         "Description": "Unique cricket and coding crossover contest - The high-energy event brilliantly combined strategic thinking with programming challenges, creating an unforgettable experience of sportsmanship and technical skills.",
-        "img": "/Events/2024-05-23-22yardsofcode.webp"
+        "img": "/Events/2025-05-23-22yardsofcode.webp"
     }
 ]
 export default eventData;

--- a/src/components/Intro.jsx
+++ b/src/components/Intro.jsx
@@ -3,6 +3,8 @@
 import React from "react";
 import { motion } from "framer-motion";
 import "../app/intro.css";
+import eventData from "../app/events/events";
+import EventCard from "../Card/Card1";
 
 const Intro = () => {
   const fadeInUp = {
@@ -16,6 +18,11 @@ const Intro = () => {
     whileInView: { scale: 1, opacity: 1 },
     transition: { duration: 0.8, ease: "easeOut", delay: 0.5 }
   };
+
+  // Get the 3 most recent events
+  const recentEvents = [...eventData]
+    .sort((a, b) => new Date(b.ActualDate) - new Date(a.ActualDate))
+    .slice(0, 3);
 
   return (
     <div id="intro" className="flex flex-col items-center bg-gradient-to-b from-white via-blue-50 to-white">
@@ -125,32 +132,44 @@ const Intro = () => {
         whileInView="whileInView"
       >
         <h1 id="intro-head" className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-purple-600">
-         Upcoming Event
+          Recent Events
         </h1>
-        <h3 className="bold-text text-blue-700">CodeRIT's 22 Yards Of Code!</h3>
-        <motion.div
-          className="inline-block mt-4 mb-4"
-          whileHover={{ scale: 1.02 }}
-        >
-          <motion.img
-            src="./poster.png"
-            alt="Image"
-            className="h-[32rem] rounded-lg shadow-lg hover:shadow-2xl transition-shadow duration-300"
-            whileHover={{ scale: 1.02 }}
-            transition={{ duration: 0.3 }}
-          />
-          <br />
-          {/* <motion.a
-            href="/whackiest-registration"
+        
+        {/* Events Grid - Responsive: 1 on mobile, 3 on desktop */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-7xl mx-auto mt-8">
+          {recentEvents.map((event, index) => (
+            <motion.div
+              key={index}
+              className={`${index > 0 ? 'hidden lg:block' : ''}`}
+              variants={scaleIn}
+              initial="initial"
+              whileInView="whileInView"
+              viewport={{ once: true }}
+            >
+              <EventCard
+                name={event.Name}
+                year={event.Year}
+                date={event.Date}
+                description={event.Description}
+                url={event.img}
+              />
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Show All Events Button */}
+        <motion.div className="mt-8 mb-8">
+          <motion.a
+            href="/events"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             className="inline-flex items-center px-6 sm:px-8 py-2 sm:py-3 
-    bg-gradient-to-r from-blue-600 to-purple-600
-    text-white font-bold rounded-full 
-    hover:shadow-lg transition-all duration-300"
+              bg-gradient-to-r from-blue-600 to-purple-600
+              text-white font-bold rounded-full 
+              hover:shadow-lg transition-all duration-300"
           >
-            Register Now
-          </motion.a> */}
+            Show All Events
+          </motion.a>
         </motion.div>
       </motion.div>
     </div>


### PR DESCRIPTION
Remove 22 Yards of Code event from homepage and replace with recent events section

- Removed the static "22 Yards of Code" upcoming event section from homepage
- Added dynamic "Recent Events" section that displays the 3 most recent events
- Implemented responsive design: shows 3 events on desktop/laptop, 1 event on mobile
- Reused existing EventCard component for consistent styling
- Added "Show All Events" button that redirects to /events page
- Events are automatically sorted by date (most recent first) from eventData
- Bonus fix: Corrected image path for 22 Yards of Code event